### PR TITLE
Release v3.4.1

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -1,34 +1,25 @@
-# Local testing workflow that can be run with act
-# Install act: https://github.com/nektos/act
-# Run: act -j test
-
+# Local testing workflow for `act` (https://github.com/nektos/act).
+# Manual-only on GitHub: real CI lives in test.yml. This file exists so
+# you can iterate locally with: act -j test
 name: test-local
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        emacs_version: [27.1, 28.2, 29.1]
-    
     steps:
-      - uses: actions/checkout@v3
-      
-      - name: Install Emacs ${{ matrix.emacs_version }}
+      - uses: actions/checkout@v4
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 29.4
+      - name: Install dependencies
         run: |
           sudo apt-get update
-          if [[ "${{ matrix.emacs_version }}" == "27.1" ]]; then
-            sudo apt-get install -y emacs
-          else
-            # For newer versions, we'd need to add PPA or build from source
-            sudo add-apt-repository -y ppa:kelleyk/emacs
-            sudo apt-get update
-            sudo apt-get install -y emacs28
-          fi
-          
+          sudo apt-get install -y libvterm-dev
       - name: Show Emacs version
         run: emacs --version
-        
       - name: Run tests
-        run: ./run-tests.sh
+        run: |
+          chmod +x ./tests/run_tests.sh
+          ./tests/run_tests.sh

--- a/src/ecc-auto-response-core.el
+++ b/src/ecc-auto-response-core.el
@@ -63,7 +63,11 @@
 
 (defvar --ecc-auto-response-safe-interval 1.0)
 
-(defvar --ecc-auto-response-responses nil)
+;; Forward declaration — no initial value, so we don't shadow the real
+;; defcustom in ecc-auto-response.el when this file is loaded first
+;; (e.g. through a test that requires ecc-auto-response-core directly).
+
+(defvar --ecc-auto-response-responses)
 
 (defvar-local --ecc-auto-response--enabled nil)
 

--- a/src/ecc-auto-response-retry.el
+++ b/src/ecc-auto-response-retry.el
@@ -55,11 +55,13 @@ Fewer than :waiting retries since these need full text re-send."
 ;; 3. Variables
 ;; ----------------------------------------
 
-(defvar --ecc-auto-response-responses nil
-  "Stub; real value defined in ecc-auto-response.el.")
+;; Forward declarations — no initial value, so we don't shadow the real
+;; defcustom in ecc-auto-response.el when this file is loaded first
+;; (e.g. through a test that requires ecc-auto-response-retry directly).
 
-(defvar --ecc-auto-response-safe-interval 1.0
-  "Stub; real value defined in ecc-auto-response.el.")
+(defvar --ecc-auto-response-responses)
+
+(defvar --ecc-auto-response-safe-interval)
 
 ;; 4. Main Entry Points
 ;; ----------------------------------------

--- a/src/ecc.el
+++ b/src/ecc.el
@@ -13,7 +13,7 @@
   :prefix "--ecc-"
   :group 'tools)
 
-(defconst --ecc-version "3.4.0"
+(defconst --ecc-version "3.4.1"
   "Current version of the emacs-claude-code package.")
 
 ;; 2. Dependencies


### PR DESCRIPTION
## Summary

Patch release fixing CI test failures and the broken `test-local` workflow.

- Fix load-order bug: stub `defvar --ecc-auto-response-responses nil` in retry.el / core.el shadowed the real `defcustom`, causing `:y/n` and `:waiting` to vanish from the alist when test files loaded under C locale (CI). Converted to bare forward declarations.
- `test-local.yml` workflow restricted to `workflow_dispatch` (was failing on every push due to a stale kelleyk PPA on Ubuntu 24.04 + outdated script path).

## Test plan
- [x] `LC_ALL=C bash tests/run_tests.sh` → 260/260 pass locally
- [x] CI matrix passed on develop: 28.2 / 29.1 / 29.4 / 30.1 / snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)