### PR TITLE
ci: move require-integrity to self-hosted; keep the Emacs matrix hosted with reasoned PS-224 exemptions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,13 @@ jobs:
   # present on the Spartan self-hosted node (RHEL 9.8, git 2.52, bash 5.1.8,
   # PCRE grep), so this job carries no GitHub-hosted dependency and moves to
   # the org pool per the no-hosted-runners mandate (2026-07-14).
+  # Label set matches the org convention (all 8 jobs across the six
+  # scitex-ai/.github reusables use exactly this list). Deliberately NOT
+  # `scitex-ci`: only 1 of the 3 online runners carries that label, whereas
+  # `spartan-cpu` matches all 3. Both are registered destinations, so both
+  # satisfy PS-224; this one just has 3x the dispatch capacity.
   require-integrity:
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
+    runs-on: [self-hosted, Linux, X64, spartan-cpu]
     steps:
       - uses: actions/checkout@v4
       - name: Check require integrity

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,24 @@ on:
       - 'LICENSE'
       - 'CHANGELOG.md'
 jobs:
+  # Pure-shell gate: bash + git + GNU grep -oP only, no Emacs. Verified
+  # present on the Spartan self-hosted node (RHEL 9.8, git 2.52, bash 5.1.8,
+  # PCRE grep), so this job carries no GitHub-hosted dependency and moves to
+  # the org pool per the no-hosted-runners mandate (2026-07-14).
   require-integrity:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted","Linux","X64","scitex-ci"]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Check require integrity
         run: |
           chmod +x ./tests/check_requires.sh
           ./tests/check_requires.sh
+  # STAYS GitHub-hosted — deliberately, not by omission. See
+  # .scitex/dev/config.yaml `audit.exemptions` (PS-224) for the full reason:
+  # purcell/setup-emacs installs Nix (needs root), the build needs
+  # `sudo apt-get install libvterm-dev`, and none of the five matrix Emacs
+  # versions exists on the Spartan node. All three are impossible on an
+  # unprivileged HPC compute node.
   test:
     needs: require-integrity
     runs-on: ubuntu-24.04

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -1,0 +1,67 @@
+# scitex-dev project config for emacs-claude-code.
+#
+# This repo is an EMACS LISP package, not a Python distribution. The fleet
+# CI template does not apply here: `scitex-dev ecosystem ci-template apply`
+# refuses outright with `error: no pyproject.toml`, and all three
+# test-shaped org reusables (pytest-matrix, import-smoke, quality-audit)
+# are hard-wired to uv + `src/<pkg>` + pyproject and expose zero inputs, so
+# none can run an ERT suite.
+
+audit:
+  exemptions:
+    # PS-224 — `runs-on` must name a destination the machine registry serves.
+    #
+    # NOTE FOR THE READER: as of scitex-dev 0.38.0 these entries are INERT.
+    # `_run_checks.py` calls `check_ps224_runner_destinations(repo_root,
+    # Violation, violations)` with no `config` argument, and the checker
+    # never calls `exemption_for`, so PS-224 cannot currently be exempted
+    # even though its own docstring and violation text advertise this exact
+    # surface. Only PS-220/PS-222/PS-223 consult exemptions today. These
+    # entries are written to the documented schema so they take effect the
+    # moment PS-224 is wired up (PS-222 already has the line-less precedent:
+    # `exemption_for("PS-222", rel, _NO_LINE)` with `_NO_LINE = 0`).
+    PS-224:
+      - path: .github/workflows/test.yml
+        line: 0
+        reason: >-
+          Job `test` cannot run on the Spartan self-hosted pool, which is an
+          UNPRIVILEGED HPC compute node (RHEL 9.8, bare metal, no root, no
+          systemd, no package manager), measured 2026-07-28. Three
+          independent hard blockers, any one of which is fatal:
+          (1) `purcell/setup-emacs@master` is a thin wrapper that installs
+          NIX -- its install.sh shells install-nix.sh, which requires root
+          (`sudo mkdir -p /etc/nix`, or a `--daemon` install needing
+          systemd) and then `nix profile install
+          github:purcell/nix-emacs-ci#emacs-<ver>`. The node has no nix and
+          no /nix, and `sudo` is refused cluster-wide.
+          (2) The build step runs `sudo apt-get install -y libvterm-dev`.
+          The node is RHEL, has NO apt-get at all, and no sudo, so the
+          vterm headers cannot be obtained.
+          (3) The matrix pins five Emacs versions (28.2, 29.1, 29.4, 30.1,
+          snapshot). The node offers only system Emacs 27.2 and module
+          Emacs/28.1 -- NONE of the five. Testing across released Emacs
+          versions is the entire purpose of this job, so dropping the matrix
+          would delete the coverage rather than relocate it.
+          The `ubuntu-24.04` pin is therefore load-bearing in the weak sense
+          that the job needs a Debian-family image with apt and root; it is
+          NOT load-bearing on 24.04 specifically (this repo ran the same job
+          on ubuntu-22.04 until commit d14a30d flipped it to 24.04 with no
+          incident). Sibling job `require-integrity` in this same file HAS
+          been migrated to the org pool -- only `test` is exempt.
+          Revisit if Emacs is ever baked into the ci-cpu Apptainer image.
+      - path: .github/workflows/test-local.yml
+        line: 0
+        reason: >-
+          Job `test` in test-local.yml is a LOCAL-ONLY harness for
+          nektos/act (`act -j test`), gated `on: workflow_dispatch` so it
+          never runs on GitHub in normal operation. Under act,
+          `ubuntu-latest` is not a GitHub-hosted runner label at all -- it
+          is the key act maps to a Docker image
+          (catthehacker/ubuntu:act-latest). Rewriting it to self-hosted
+          labels would break the file's only purpose without moving any
+          real CI, since the actual CI lives in test.yml. PS-224's stated
+          harm -- "GitHub queues an unmatchable job forever" -- cannot occur
+          here: the job is never auto-dispatched, and on the rare manual
+          dispatch `ubuntu-latest` IS served by GitHub and runs fine.
+          It also inherits blockers (1) and (2) from the test.yml entry,
+          since it performs the same setup-emacs + apt-get steps.


### PR DESCRIPTION
## Summary

PS-224 (scitex-dev 0.38.0) flags 3 jobs here. This repo is the fleet outlier: its violations are **not** `ubuntu-latest` but a deliberate `ubuntu-24.04` pin, so each job was assessed on its actual steps rather than swapped blindly.

Result: **1 job moved, 2 stay hosted with individually reasoned exemptions.** Checker count 3 → 2, both deliberate.

## Per-job verdict

| Job | File | Verdict |
|---|---|---|
| `require-integrity` | test.yml | **MOVED** to the org self-hosted pool |
| `test` | test.yml | **STAYS HOSTED** — cannot run on Spartan |
| `test` | test-local.yml | **STAYS HOSTED** — `act`-only harness |

### `require-integrity` — moved

`tests/check_requires.sh` is pure shell: bash, git, and GNU `grep -oP`. No Emacs, no apt, no root, no display. Probed directly on the Spartan node (2026-07-28): RHEL 9.8, git 2.52.0, bash 5.1.8, PCRE grep works, node20 present for `actions/checkout@v4`. Nothing tied this job to a hosted image.

### `test` — cannot move

Three independent blockers, each fatal on its own, measured on the Spartan node:

1. **`purcell/setup-emacs@master` installs Nix.** Its `action.yml` shells `install.sh`, which shells `install-nix.sh` when nix is absent. That needs root — a `--daemon` install via systemd, or the fallback branch which literally runs `sudo mkdir -p /etc/nix`. Then `nix profile install github:purcell/nix-emacs-ci#emacs-<ver>`. The node has no nix, no `/nix`, and sudo is refused cluster-wide.
2. **`sudo apt-get install -y libvterm-dev`.** The node is RHEL — no `apt-get` at all, and no sudo.
3. **The version matrix has nowhere to land.** It pins Emacs 28.2 / 29.1 / 29.4 / 30.1 / snapshot. The node offers only system Emacs 27.2 and module `Emacs/28.1` — none of the five. Testing across released Emacs versions *is* this job; dropping the matrix would delete the coverage, not relocate it.

On the pin itself: `ubuntu-24.04` is load-bearing only in the weak sense that the job needs a Debian-family image with apt and root. It is **not** load-bearing on 24.04 specifically — this repo ran the same job on `ubuntu-22.04` until d14a30d flipped it to 24.04 with no incident. So the pin is not the obstacle; the privilege model is.

### `test-local.yml` — cannot move

A `nektos/act` harness, `on: workflow_dispatch` only, documented in-file as "real CI lives in test.yml". Under `act`, `ubuntu-latest` is not a GitHub runner label — it is the key act maps to a Docker image (`catthehacker/ubuntu:act-latest`). Rewriting it to self-hosted labels breaks its only purpose while moving no real CI. PS-224's stated harm ("GitHub queues an unmatchable job forever") cannot occur here: it is never auto-dispatched, and on a manual dispatch `ubuntu-latest` is served by GitHub and runs fine.

## Why not `ci-template apply`

It refuses this repo outright:

```
error: no pyproject.toml at <repo>
```

This is an Emacs Lisp package. All three test-shaped org reusables (`pytest-matrix`, `import-smoke`, `quality-audit`) are hard-wired to uv + `src/<pkg>` + `pyproject.toml` and declare `workflow_call: {}` — zero inputs, so there is no seam to run an ERT suite through. No org reusable fits, and no repo in the fleet currently runs Emacs on the self-hosted pool.

## Known gap this surfaced (needs a follow-up in scitex-dev)

**PS-224 does not honour `audit.exemptions` at all.** `_run_checks.py` calls:

```python
check_ps224_runner_destinations(repo_root, Violation, violations)
```

— no `config` argument — and the checker never calls `exemption_for`. Only PS-220 / PS-222 / PS-223 consult exemptions today. So the escape hatch that PS-224's own docstring and violation text advertise ("Exempt a single site only via `audit.exemptions` with a stated reason") is currently **inert**.

The entries in this PR are written to the documented schema and parse clean (2 accepted, 0 rejected), so they take effect the moment PS-224 is wired. PS-222 already provides the line-less precedent: `exemption_for("PS-222", rel, _NO_LINE)` with `_NO_LINE = 0`.

Second-order wrinkle for whoever wires it: PS-224 reports per **job**, but `where` carries only the file path. `test.yml` holds both an exempt job (`test`) and a migrated one (`require-integrity`), so a path-only exemption would over-exempt. The violation likely needs a job-qualified site key.

## Verification

```
$ python -c "...check_ps224_runner_destinations(Path(repo), Violation, out)..."
PS-224 COUNT: 2
  .github/workflows/test-local.yml | job `test` targets `[ubuntu-latest]`
  .github/workflows/test.yml       | job `test` targets `[ubuntu-24.04]`
```

Both remaining hits are the two deliberately exempted jobs. `require-integrity` is clean.

## Reviewer note — the one real risk

`require-integrity` gates the test matrix via `needs:`, and the matrix stays hosted. This PR therefore makes a hosted 5-leg matrix depend on the self-hosted pool. The pool is a SLURM-leased HPC node, so if the lease lapses the whole `tests` workflow stalls rather than just this gate. CI on this PR is the live test of that coupling. If it proves fragile, the clean fallback is to drop `needs:` and let the two jobs run independently.
